### PR TITLE
Resolves #5 replay game

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -71,5 +71,17 @@ func ReplayGame(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fmt.Fprintf(w, "%v\n", shots.ReplayGame(ships, gameShots))
+	res := shots.ReplayGame(ships, gameShots)
+	fmt.Fprintf(w, "Untouched:\n")
+	for _, s := range res.Untouched {
+		fmt.Fprintf(w, "%v\n", s)
+	}
+	fmt.Fprintf(w, "Damaged:\n")
+	for _, s := range res.Damaged {
+		fmt.Fprintf(w, "%v\n", s)
+	}
+	fmt.Fprintf(w, "Destroyed:\n")
+	for _, s := range res.Destroyed {
+		fmt.Fprintf(w, "%v\n", s)
+	}
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -27,11 +27,11 @@ func ValidateShipPlacement(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	layout, err := layout.ParseLayout(string(b))
+	gameLayout, _, err := layout.ParseLayout(string(b))
 	if err != nil {
 		log.Info("error when reading body: ", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fmt.Fprintf(w, "%v\n", validate.Validate(layout))
+	fmt.Fprintf(w, "%v\n", validate.Validate(gameLayout))
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -47,7 +47,7 @@ func ReplayGame(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	s := string(b)
-	bodyParts := strings.Split(s, "@")
+	bodyParts := strings.Split(s, "\n+\n")
 	if len(bodyParts) != 2 {
 		err := fmt.Errorf("more than 2 parts (ships and shots) detected")
 		log.Info("error when reading body: ", err)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -24,13 +24,13 @@ func ValidateShipPlacement(w http.ResponseWriter, req *http.Request) {
 	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Info("error when reading body: ", err)
-		http.Error(w, err.Error(), 400)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	layout, err := layout.ParseLayout(string(b))
 	if err != nil {
 		log.Info("error when reading body: ", err)
-		http.Error(w, err.Error(), 400)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	fmt.Fprintf(w, "%v\n", validate.Validate(layout))

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"slava0135/nanoservice/generate"
 	"slava0135/nanoservice/layout"
+	"slava0135/nanoservice/shots"
 	"slava0135/nanoservice/validate"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -34,4 +36,40 @@ func ValidateShipPlacement(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	fmt.Fprintf(w, "%v\n", validate.Validate(gameLayout))
+}
+
+func ReplayGame(w http.ResponseWriter, req *http.Request) {
+	log.Info("handle replay game request")
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		log.Info("error when reading body: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s := string(b)
+	bodyParts := strings.Split(s, "@")
+	if len(bodyParts) != 2 {
+		err := fmt.Errorf("more than 2 parts (ships and shots) detected")
+		log.Info("error when reading body: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	gameLayout, ships, err := layout.ParseLayout(bodyParts[0])
+	if err != nil {
+		log.Info("error when reading body: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !validate.Validate(gameLayout) {
+		log.Info("user provided invalid ship layout")
+		http.Error(w, "invalid ship layout", http.StatusBadRequest)
+		return
+	}
+	gameShots, err := shots.ParseShots(bodyParts[1])
+	if err != nil {
+		log.Info("user provided invalid shots data: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	fmt.Fprintf(w, "%v\n", shots.ReplayGame(ships, gameShots))
 }

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -35,20 +35,20 @@ func NewShip(x1, y1, x2, y2 uint) Ship {
 	return Ship{Point{x1, y1}, Point{x2, y2}}
 }
 
-func ParseLayout(s string) (l Layout, err error) {
-	var layout Layout
+func ParseLayout(s string) (layout Layout, ships []Ship, err error) {
 	for i, line := range strings.Split(s, "\n") {
 		var x1, y1, x2, y2 uint
 		_, err := fmt.Sscanf(line, "{{%d %d} {%d %d}}", &x1, &y1, &x2, &y2)
 		if err != nil {
-			return layout, fmt.Errorf("failed to parse line %d: %v", i+1, err)
+			return layout, ships, fmt.Errorf("failed to parse line %d: %v", i+1, err)
 		}
 		if x1 != x2 && y1 != y2 {
-			return layout, fmt.Errorf("failed to parse line %d: points are not on the same line", i+1)
+			return layout, ships, fmt.Errorf("failed to parse line %d: points are not on the same line", i+1)
 		}
 		if x1 >= rules.N || x2 >= rules.N || y1 >= rules.N || y2 >= rules.N {
-			return layout, fmt.Errorf("failed to parse line %d: points are outside of game field", i+1)
+			return layout, ships, fmt.Errorf("failed to parse line %d: points are outside of game field", i+1)
 		}
+		ships = append(ships, NewShip(x1, y1, x2, y2))
 		if x1 != x2 {
 			var x_low, x_high uint
 			if x1 < x2 {
@@ -71,7 +71,7 @@ func ParseLayout(s string) (l Layout, err error) {
 			}
 		}
 	}
-	return layout, nil
+	return layout, ships, nil
 }
 
 func LinkedSquares(x, y uint) []Point {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	port := ":8080"
 	http.HandleFunc("/generate", handlers.GenerateGameLayout)
 	http.HandleFunc("/validate", handlers.ValidateShipPlacement)
+	http.HandleFunc("/replay", handlers.ReplayGame)
 	log.Info("listening on port ", port)
 	log.Fatal(http.ListenAndServe(port, nil))
 }

--- a/shots/shots.go
+++ b/shots/shots.go
@@ -29,5 +29,45 @@ func ParseShots(s string) ([]layout.Point, error) {
 
 func ReplayGame(ships []layout.Ship, shots []layout.Point) Results {
 	var res Results
+	for _, ship := range ships {
+		var segments []layout.Point
+		if ship.P1.X != ship.P2.X {
+			var x_low, x_high uint
+			if ship.P1.X < ship.P2.X {
+				x_low, x_high = ship.P1.X, ship.P2.X
+			} else {
+				x_low, x_high = ship.P2.X, ship.P1.X
+			}
+			for x := x_low; x <= x_high; x++ {
+				segments = append(segments, layout.Point{X: x, Y: ship.P1.Y})
+			}
+		} else {
+			var y_low, y_high uint
+			if ship.P1.Y < ship.P2.Y {
+				y_low, y_high = ship.P1.Y, ship.P2.Y
+			} else {
+				y_low, y_high = ship.P1.Y, ship.P2.Y
+			}
+			for y := y_low; y <= y_high; y++ {
+				segments = append(segments, layout.Point{X: ship.P1.X, Y: y})
+			}
+		}
+		length := len(segments)
+		for _, shot := range shots {
+			for i := 0; i < len(segments); i++ {
+				if shot == segments[i] {
+					segments = append(segments[:i], segments[i+1:]...)
+					break
+				}
+			}
+		}
+		if length == len(segments) {
+			res.Untouched = append(res.Untouched, ship)
+		} else if len(segments) == 0 {
+			res.Destroyed = append(res.Destroyed, ship)
+		} else {
+			res.Damaged = append(res.Damaged, ship)
+		}
+	}
 	return res
 } 

--- a/shots/shots.go
+++ b/shots/shots.go
@@ -1,0 +1,33 @@
+package shots
+
+import (
+	"fmt"
+	"slava0135/nanoservice/layout"
+	"slava0135/nanoservice/rules"
+	"strings"
+)
+
+type Results struct {
+	Untouched, Damaged, Destroyed []layout.Ship 
+}
+
+func ParseShots(s string) ([]layout.Point, error) {
+	var shots []layout.Point
+	for i, line := range strings.Split(s, "\n") {
+		var x, y uint
+		_, err := fmt.Sscanf(line, "{%d %d}", &x, &y)
+		if err != nil {
+			return shots, fmt.Errorf("failed to parse line %d: %v", i+1, err)
+		}
+		if x >= rules.N || y >= rules.N {
+			return shots, fmt.Errorf("failed to parse line %d: shots are outside of game field", i+1)
+		}
+		shots = append(shots, layout.Point{X: x, Y: y})
+	}
+	return shots, nil
+}
+
+func ReplayGame(ships []layout.Ship, shots []layout.Point) Results {
+	var res Results
+	return res
+} 


### PR DESCRIPTION
Implements game replay, example:
```text
curl -i http://localhost:8080/replay -d "{{7 5} {7 5}}
{{2 7} {2 7}}
{{2 3} {2 3}}
{{0 5} {0 5}}
{{6 2} {7 2}}
{{3 9} {4 9}}
{{9 3} {9 4}}
{{4 1} {4 3}}
{{6 8} {8 8}}
{{2 5} {5 5}}
+
{0 0}
{9 4}
{9 3}
{5 5}"
```

Response:
```text
Untouched:
{{7 5} {7 5}}
{{2 7} {2 7}}
{{2 3} {2 3}}
{{0 5} {0 5}}
{{6 2} {7 2}}
{{3 9} {4 9}}
{{4 1} {4 3}}
{{6 8} {8 8}}
Damaged:
{{2 5} {5 5}}
Destroyed:
{{9 3} {9 4}}
```

if game layout is not valid error will be returned
