### PR TITLE
7 export and import as grid

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -23,6 +23,12 @@ func GenerateGameLayout(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func GenerateGameLayoutGrid(w http.ResponseWriter, req *http.Request) {
+	log.Info("handle generate game layout as grid request")
+	layout, _ := generate.NewGameLayout()
+	fmt.Fprintf(w, "%v\n", layout)
+}
+
 func GenerateGameLayoutImage(w http.ResponseWriter, req *http.Request) {
 	log.Info("handle generate game layout as image request")
 	layout, _ := generate.NewGameLayout()

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -116,22 +116,20 @@ func ShipsFromLayout(layout Layout) []Ship {
 				if checked[x][y] {
 					continue
 				}
-				checked[x][y] = true
-				length := 0
 				xl, yl := x, y 
 				for ; xl < rules.N; xl++ {
 					if !layout[xl][y] {
 						break
 					}
-					length++
 					checked[xl][y] = true
 				}
-				for ; yl < rules.N; yl++ {
-					if !layout[x][yl] {
-						break
+				if x == xl {
+					for ; yl < rules.N; yl++ {
+						if !layout[x][yl] {
+							break
+						}
+						checked[x][yl] = true
 					}
-					length++
-					checked[x][yl] = true
 				}
 				ships = append(ships, NewShip(x, y, xl, yl))
 			}

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -99,7 +99,7 @@ func ParseLayoutGrid(s string) (layout Layout, ships []Ship, err error) {
 			case emptyChar:
 				layout[x][y] = false
 			default:
-				return layout, ships, fmt.Errorf("line %d has invalid char at pos %d", x+1, y+1)
+				return layout, ships, fmt.Errorf("line %d has invalid char `%c` at pos %d", x+1, c, y+1)
 			}
 		}
 	}

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -116,14 +116,17 @@ func ShipsFromLayout(layout Layout) []Ship {
 				if checked[x][y] {
 					continue
 				}
-				xl, yl := x, y 
-				for ; xl < rules.N; xl++ {
-					if !layout[xl][y] {
-						break
+				checked[x][y] = true
+				xl, yl := x, y
+				if x < rules.N-1 && layout[x+1][y] {
+					for ; xl < rules.N; xl++ {
+						if !layout[xl][y] {
+							break
+						}
+						checked[xl][y] = true
 					}
-					checked[xl][y] = true
 				}
-				if x == xl {
+				if y < rules.N-1 && layout[x][y+1] {
 					for ; yl < rules.N; yl++ {
 						if !layout[x][yl] {
 							break

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	shipChar  = '#'
+	emptyChar = 'o'
+)
+
 type Layout [rules.N][rules.N]bool
 
 type Point struct {
@@ -21,9 +26,9 @@ func (l Layout) String() string {
 	for _, v := range l {
 		for _, v := range v {
 			if v {
-				sb.WriteByte('#')
+				sb.WriteByte(shipChar)
 			} else {
-				sb.WriteByte('o')
+				sb.WriteByte(emptyChar)
 			}
 		}
 		sb.WriteByte('\n')
@@ -36,6 +41,14 @@ func NewShip(x1, y1, x2, y2 uint) Ship {
 }
 
 func ParseLayout(s string) (layout Layout, ships []Ship, err error) {
+	if strings.HasPrefix(s, "{") {
+		return ParseLayoutShips(s)
+	} else {
+		return ParseLayoutGrid(s)
+	}
+}
+
+func ParseLayoutShips(s string) (layout Layout, ships []Ship, err error) {
 	for i, line := range strings.Split(s, "\n") {
 		var x1, y1, x2, y2 uint
 		_, err := fmt.Sscanf(line, "{{%d %d} {%d %d}}", &x1, &y1, &x2, &y2)
@@ -72,6 +85,59 @@ func ParseLayout(s string) (layout Layout, ships []Ship, err error) {
 		}
 	}
 	return layout, ships, nil
+}
+
+func ParseLayoutGrid(s string) (layout Layout, ships []Ship, err error) {
+	for x, line := range strings.Split(s, "\n") {
+		if len(line) != rules.N {
+			return layout, ships, fmt.Errorf("line %d has invalid length", x+1)
+		}
+		for y, c := range line {
+			switch c {
+			case shipChar:
+				layout[x][y] = true
+			case emptyChar:
+				layout[x][y] = false
+			default:
+				return layout, ships, fmt.Errorf("line %d has invalid char at pos %d", x+1, y+1)
+			}
+		}
+	}
+	ships = ShipsFromLayout(layout)
+	return layout, ships, nil
+}
+
+func ShipsFromLayout(layout Layout) []Ship {
+	var ships []Ship
+	var checked Layout
+	for x := uint(0); x < rules.N; x++ {
+		for y := uint(0); y < rules.N; y++ {
+			if layout[x][y] {
+				if checked[x][y] {
+					continue
+				}
+				checked[x][y] = true
+				length := 0
+				xl, yl := x, y 
+				for ; xl < rules.N; xl++ {
+					if !layout[xl][y] {
+						break
+					}
+					length++
+					checked[xl][y] = true
+				}
+				for ; yl < rules.N; yl++ {
+					if !layout[x][yl] {
+						break
+					}
+					length++
+					checked[x][yl] = true
+				}
+				ships = append(ships, NewShip(x, y, xl, yl))
+			}
+		}
+	}
+	return ships
 }
 
 func LinkedSquares(x, y uint) []Point {

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -90,7 +90,7 @@ func ParseLayoutShips(s string) (layout Layout, ships []Ship, err error) {
 func ParseLayoutGrid(s string) (layout Layout, ships []Ship, err error) {
 	for y, line := range strings.Split(s, "\n") {
 		if len(line) != rules.N {
-			return layout, ships, fmt.Errorf("line %d has invalid length", x+1)
+			return layout, ships, fmt.Errorf("line %d has invalid length", y+1)
 		}
 		for x, c := range line {
 			switch c {

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -88,11 +88,11 @@ func ParseLayoutShips(s string) (layout Layout, ships []Ship, err error) {
 }
 
 func ParseLayoutGrid(s string) (layout Layout, ships []Ship, err error) {
-	for x, line := range strings.Split(s, "\n") {
+	for y, line := range strings.Split(s, "\n") {
 		if len(line) != rules.N {
 			return layout, ships, fmt.Errorf("line %d has invalid length", x+1)
 		}
-		for y, c := range line {
+		for x, c := range line {
 			switch c {
 			case shipChar:
 				layout[x][y] = true

--- a/main.go
+++ b/main.go
@@ -13,11 +13,13 @@ func main() {
 	log.Info("starting up")
 	rand.Seed(time.Now().UnixNano())
 
-	port := ":8080"
 	http.HandleFunc("/generate", handlers.GenerateGameLayout)
 	http.HandleFunc("/generate/image", handlers.GenerateGameLayoutImage)
+	http.HandleFunc("/generate/grid", handlers.GenerateGameLayoutGrid)
 	http.HandleFunc("/validate", handlers.ValidateShipPlacement)
 	http.HandleFunc("/replay", handlers.ReplayGame)
+
+	port := ":8080"
 	log.Info("listening on port ", port)
 	log.Fatal(http.ListenAndServe(port, nil))
 }


### PR DESCRIPTION
Resolves #7
Allows to export layout as grid of `o` (empty) and `#` (ship)
Example output (/generate/grid):
```text
o#ooooo#oo
o#o#ooo#oo
o#ooo#o#oo
oooooooooo
oo#ooo#ooo
#o#ooo#ooo
#ooo#o#ooo
oooooo#o#o
oooooooooo
oo##oooooo
```
Allows to import layout as grid for validation and replay.
Example:
```sh
curl -i http://localhost:8080/validate -d "#ooooooooo
#o#oooo#oo
oooo#oo#o#
ooooooo#o#
#oooo#oooo
#ooooooo#o
#ooooooo#o
#o#ooooo#o
oo#oo#oooo
oooooooooo"
```
Output:
```text
true
```
```sh
curl -i http://localhost:8080/replay -d "#ooooooooo
#o#oooo#oo
oooo#oo#o#
ooooooo#o#
#oooo#oooo
#ooooooo#o
#ooooooo#o
#o#ooooo#o
oo#oo#oooo
oooooooooo
+
{0 0}
{7 0}
{2 1}
{0 7}"
```
Output:
```text
Untouched:
{{2 7} {2 9}}
{{4 2} {4 2}}
{{5 4} {5 4}}
{{5 8} {5 8}}
{{7 1} {7 4}}
{{8 5} {8 8}}
{{9 2} {9 4}}
Damaged:
{{0 0} {0 2}}
{{0 4} {0 8}}
Destroyed:
{{2 1} {2 1}}
```

